### PR TITLE
libcurl4-gnutls-dev -> libcurl4-dev

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libluajit-5.1-dev"
+pkg_dependencies="build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libluajit-5.1-dev"
 
 #=================================================
 # EXPERIMENTAL HELPERS


### PR DESCRIPTION
Randomly passing by, we're trying to fix some weird cross-apps conflicts because of stupid dependency conflicts ... in particular various app require different versions of libcurl4-*-dev conflicting with each other, but it should be fine to just request libcurl4-dev
