### PR TITLE
No is_public anymore, use ynh_permission_has_user

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -168,7 +168,9 @@ popd
 # UPDATE A CONFIG FILE
 #=================================================
 ynh_script_progression --message="Updating a configuration file..."
-if [ $is_public -eq 1 ]; then
+
+if ynh_permission_has_user --permission=main --user=visitors
+then
 	announce="true"
 else
 	announce="fase"


### PR DESCRIPTION
## Problem

- Not sure how the upgrade doesn't miserably crash, but as spotted on the CI, $is_public is now empty which breaks the `if` statement

## Solution

- Use `ynh_permission_has_user` to check if the app is exposed to visitors

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
