### PR TITLE
upgrade mineclonia to 0.93.2 - and change latest_github_tag to latest_github_release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Shipped version:** 5.8.0~ynh1
+**Shipped version:** 5.8.0~ynh2
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Minetest est un moteur de jeu voxel open-source avec modding et création de jeux faciles.
 
 
-**Version incluse :** 5.8.0~ynh1
+**Version incluse :** 5.8.0~ynh2
 
 ## Captures d’écran
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Minetest"
 description.en = "Voxel game engine and game. Need a client to connect to the server"
 description.fr = "Moteur de jeu de type « bac à sable ». Nécessite un client pour se connecter au serveur"
 
-version = "5.8.0~ynh1"
+version = "5.8.0~ynh2"
 
 maintainers = []
 
@@ -80,8 +80,8 @@ ram.runtime = "50M"
         autoupdate.strategy = "latest_github_release"
 
         [resources.sources.irrlichtmt]
-        url = "https://github.com/minetest/irrlicht/archive/1.9.0mt13.tar.gz"
-        sha256 = "2fde8e27144988210b9c0ff1e202905834d9d25aaa63ce452763fd7171096adc"
+        url = "https://github.com/minetest/irrlicht/archive/1.9.0mt14.tar.gz"
+        sha256 = "56ff07c89849df4b5a7d37e573afd7890f4c1f1d1fe010ade711193ca707306c"
         autoupdate.strategy = "latest_github_release"
 
         [resources.sources.capturetheflag]
@@ -90,8 +90,8 @@ ram.runtime = "50M"
         autoupdate.strategy = "latest_github_release"
 
         [resources.sources.mineclonia]
-        url = "https://codeberg.org/mineclonia/mineclonia/archive/0.93.2.tar.gz"
-        sha256 = "d4c237d85ffee1b41b3dac8b01589685ff4f806d5273bb47eb4cc7e4f443c27d"
+        url = "https://codeberg.org/mineclonia/mineclonia/archive/0.94.0.tar.gz"
+        sha256 = "ad3b0dfabb442b47d3b54f0dd6bc5c882573e98c2c924a29ea395b9a59d0bde6"
         autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -72,27 +72,27 @@ ram.runtime = "50M"
         [resources.sources.minetest_game]
         url = "https://github.com/minetest/minetest_game/archive/5.8.0.tar.gz"
         sha256 = "33a3bb43b08497a0bdb2f49f140a2829e582d5c16c0ad52be1595c803f706912"
-        autoupdate.strategy = "latest_github_tag"
+        autoupdate.strategy = "latest_github_release"
 
         [resources.sources.main]
         url = "https://github.com/minetest/minetest/archive/5.8.0.tar.gz"
         sha256 = "610c85a24d77acdc3043a69d777bed9e6c00169406ca09df22ad490fe0d68c0c"
-        autoupdate.strategy = "latest_github_tag"
+        autoupdate.strategy = "latest_github_release"
 
         [resources.sources.irrlichtmt]
         url = "https://github.com/minetest/irrlicht/archive/1.9.0mt13.tar.gz"
         sha256 = "2fde8e27144988210b9c0ff1e202905834d9d25aaa63ce452763fd7171096adc"
-        autoupdate.strategy = "latest_github_tag"
+        autoupdate.strategy = "latest_github_release"
 
         [resources.sources.capturetheflag]
         url = "https://github.com/MT-CTF/capturetheflag/archive/refs/tags/v3.7.tar.gz"
         sha256 = "d81f4277761a072f0516e1363e7fa171a9f25b55d4c5f2e0114544fa8f9df99d"
-        autoupdate.strategy = "latest_github_tag"
+        autoupdate.strategy = "latest_github_release"
 
         [resources.sources.mineclonia]
-        url = "https://codeberg.org/mineclonia/mineclonia/archive/0.93.1.tar.gz"
-        sha256 = "8be826d0105c7508e2c9356ffd2ae02d2d3d88932b1105277c0afa1b96e0d6af"
-        autoupdate.strategy = "latest_github_tag"
+        url = "https://codeberg.org/mineclonia/mineclonia/archive/0.93.2.tar.gz"
+        sha256 = "d4c237d85ffee1b41b3dac8b01589685ff4f806d5273bb47eb4cc7e4f443c27d"
+        autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]
 


### PR DESCRIPTION
## Problem

- Out of date game mode
- auto update bot goes crazy (cf #50 )

## Solution

- Upgrade mineclonia version
- Upgrade irrlicht version
- Replace latest_github_tag with latest_github_release

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
