### PR TITLE
Fix `bookworm` compatibility

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -120,11 +120,10 @@ ram.runtime = "50M"
                 "libgmp-dev",
                 "libjsoncpp-dev",
                 "libzstd-dev",
-                "libluajit-5.1-dev",
+                "libluajit2-5.1-dev",
                 "g++",
                 "libarchive13",
                 "libjsoncpp25",
                 "librhash0",
                 "cmake-data",
-                "libgmpxx4ldbl",
-                "libluajit-5.1-2"]
+                "libgmpxx4ldbl"]

--- a/manifest.toml
+++ b/manifest.toml
@@ -113,18 +113,9 @@ ram.runtime = "50M"
 
     [resources.apt]
     packages = ["build-essential", 
-                "libc6-dev",
                 "cmake", 
-                "libpng-dev", 
-                "libjpeg-dev",
-                "libxi-dev",
-                "libgl1-mesa-dev",
                 "libsqlite3-dev",
-                "libogg-dev",
-                "libvorbis-dev",
-                "libopenal-dev",
                 "libcurl4-gnutls-dev",
-                "libfreetype6-dev",
                 "zlib1g-dev",
                 "libgmp-dev",
                 "libjsoncpp-dev",

--- a/manifest.toml
+++ b/manifest.toml
@@ -119,11 +119,11 @@ ram.runtime = "50M"
                 "zlib1g-dev",
                 "libgmp-dev",
                 "libjsoncpp-dev",
-                "libzstd-dev",
-                "libluajit2-5.1-dev",
-                "g++",
-                "libarchive13",
-                "libjsoncpp25",
-                "librhash0",
-                "cmake-data",
-                "libgmpxx4ldbl"]
+                "libzstd-dev"]
+    packages_from_raw_bash = packages_from_raw_bash = """
+    if [[ $YNH_DEBIAN_VERSION = "bullseye" ]]; then
+        echo "libluajit-5.1-dev";
+    elif [[ $YNH_DEBIAN_VERSION = "bookworm" ]]; then
+        echo "libluajit2-5.1-dev";
+    fi
+    """

--- a/manifest.toml
+++ b/manifest.toml
@@ -34,10 +34,6 @@ ram.runtime = "50M"
     [install.domain]
     type = "domain"
 
-    [install.init_main_permission]
-    type = "group"
-    default = false
-
     [install.game]
     ask.en = "Choose a game for your server"
     ask.fr = "Choissisez un jeu pour votre serveur"

--- a/manifest.toml
+++ b/manifest.toml
@@ -121,4 +121,10 @@ ram.runtime = "50M"
                 "libjsoncpp-dev",
                 "libzstd-dev",
                 "libluajit-5.1-dev",
-                "gettext"]
+                "g++",
+                "libarchive13",
+                "libjsoncpp25",
+                "librhash0",
+                "cmake-data",
+                "libgmpxx4ldbl",
+                "libluajit-5.1-2"]

--- a/manifest.toml
+++ b/manifest.toml
@@ -120,7 +120,7 @@ ram.runtime = "50M"
                 "libgmp-dev",
                 "libjsoncpp-dev",
                 "libzstd-dev"]
-    packages_from_raw_bash = packages_from_raw_bash = """
+    packages_from_raw_bash = """
     if [[ $YNH_DEBIAN_VERSION = "bullseye" ]]; then
         echo "libluajit-5.1-dev";
     elif [[ $YNH_DEBIAN_VERSION = "bookworm" ]]; then

--- a/manifest.toml
+++ b/manifest.toml
@@ -113,6 +113,7 @@ ram.runtime = "50M"
     main.exposed = "UDP"
 
     [resources.permissions]
+    main.allowed = "visitors"
 
     [resources.apt]
     packages = "build-essential, libirrlicht-dev, cmake, libbz2-dev, libpng-dev, libjpeg-dev, libxxf86vm-dev, libgl1-mesa-dev, libsqlite3-dev, libogg-dev, libvorbis-dev, libopenal-dev, libcurl4-dev, libfreetype6-dev, zlib1g-dev, libgmp-dev, libjsoncpp-dev, libluajit-5.1-dev, libncurses-dev, libzstd-dev"

--- a/manifest.toml
+++ b/manifest.toml
@@ -112,4 +112,4 @@ ram.runtime = "50M"
     main.allowed = "visitors"
 
     [resources.apt]
-    packages = "build-essential, libirrlicht-dev, cmake, libbz2-dev, libpng-dev, libjpeg-dev, libxxf86vm-dev, libgl1-mesa-dev, libsqlite3-dev, libogg-dev, libvorbis-dev, libopenal-dev, libcurl4-dev, libfreetype6-dev, zlib1g-dev, libgmp-dev, libjsoncpp-dev, libluajit-5.1-dev, libncurses-dev, libzstd-dev"
+    packages = "build-essential, libirrlicht-dev, cmake, libbz2-dev, libpng-dev, libjpeg-dev, libxxf86vm-dev, libgl1-mesa-dev, libsqlite3-dev, libogg-dev, libvorbis-dev, libopenal-dev, libcurl4-openssl-dev, libfreetype6-dev, zlib1g-dev, libgmp-dev, libjsoncpp-dev, libluajit-5.1-dev, libncurses-dev, libzstd-dev"

--- a/manifest.toml
+++ b/manifest.toml
@@ -112,4 +112,22 @@ ram.runtime = "50M"
     main.allowed = "visitors"
 
     [resources.apt]
-    packages = "build-essential, libirrlicht-dev, cmake, libbz2-dev, libpng-dev, libjpeg-dev, libxxf86vm-dev, libgl1-mesa-dev, libsqlite3-dev, libogg-dev, libvorbis-dev, libopenal-dev, libcurl4-openssl-dev, libfreetype6-dev, zlib1g-dev, libgmp-dev, libjsoncpp-dev, libluajit-5.1-dev, libncurses-dev, libzstd-dev"
+    packages = ["build-essential", 
+                "libc6-dev",
+                "cmake", 
+                "libpng-dev", 
+                "libjpeg-dev",
+                "libxi-dev",
+                "libgl1-mesa-dev",
+                "libsqlite3-dev",
+                "libogg-dev",
+                "libvorbis-dev",
+                "libopenal-dev",
+                "libcurl4-gnutls-dev",
+                "libfreetype6-dev",
+                "zlib1g-dev",
+                "libgmp-dev",
+                "libjsoncpp-dev",
+                "libzstd-dev",
+                "libluajit-5.1-dev",
+                "gettext"]


### PR DESCRIPTION
## Problem

- Bookworm compatibility

## Solution

- Explicitly specify missing permission
- Adjust dependencies - trim down `bullseye`, enable `bookworm` build

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
