### PR TITLE
Use generic `libcurl4-dev`

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -115,7 +115,7 @@ ram.runtime = "50M"
     packages = ["build-essential", 
                 "cmake", 
                 "libsqlite3-dev",
-                "libcurl4-gnutls-dev",
+                "libcurl4-dev",
                 "zlib1g-dev",
                 "libgmp-dev",
                 "libjsoncpp-dev",


### PR DESCRIPTION
## Problem

- `apt` reporting conflicts

## Solution

- Use generic `libcurl4-dev` to let `apt` decide whether to use `gnutls` or `openssl` impl.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
