### PR TITLE
fix minetest checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Shipped version:** 5.10.0~ynh9
+**Shipped version:** 5.10.0~ynh10
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Versión actual:** 5.10.0~ynh9
+**Versión actual:** 5.10.0~ynh10
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Paketatutako bertsioa:** 5.10.0~ynh9
+**Paketatutako bertsioa:** 5.10.0~ynh10
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Minetest est un moteur de jeu voxel open-source avec modding et création de jeux faciles.
 
 
-**Version incluse :** 5.10.0~ynh9
+**Version incluse :** 5.10.0~ynh10
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Versión proporcionada:** 5.10.0~ynh9
+**Versión proporcionada:** 5.10.0~ynh10
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Versi terkirim:** 5.10.0~ynh9
+**Versi terkirim:** 5.10.0~ynh10
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Geleverde versie:** 5.10.0~ynh9
+**Geleverde versie:** 5.10.0~ynh10
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Dostarczona wersja:** 5.10.0~ynh9
+**Dostarczona wersja:** 5.10.0~ynh10
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**Поставляемая версия:** 5.10.0~ynh9
+**Поставляемая версия:** 5.10.0~ynh10
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Minetest is a free open-source voxel game engine with easy modding and game creation.
 
 
-**分发版本：** 5.10.0~ynh9
+**分发版本：** 5.10.0~ynh10
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -75,7 +75,7 @@ ram.runtime = "50M"
 
         [resources.sources.main]
         url = "https://github.com/minetest/minetest/archive/refs/tags/5.10.0.tar.gz"
-        sha256 = "2a3161c04e7389608006f01280eda30507f8bacfa1d6b64c2af1b820a62d2677"
+        sha256 = "13c559566937cfd9ed1cde594c20e7ab52f86dee0816ba12e828b14bb8e2c6ac"
         autoupdate.strategy = "latest_github_release"
 
         [resources.sources.irrlichtmt]

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Minetest"
 description.en = "Voxel game engine and game. Need a client to connect to the server"
 description.fr = "Moteur de jeu de type « bac à sable ». Nécessite un client pour se connecter au serveur"
 
-version = "5.10.0~ynh9"
+version = "5.10.0~ynh10"
 
 maintainers = []
 

--- a/tests.toml
+++ b/tests.toml
@@ -23,6 +23,7 @@ test_format = 1.0
     # -------------------------------
 
     test_upgrade_from.7502e8155e0e5ee5d9e346af3ed96e431cd9fba3.name = "Upgrade from 5.5.1~ynh2"
+    test_upgrade_from.5e3ed220af8aae9a4783f92066224894923fce8b.name = "Upgrade from 5.8.0~ynh1"
 
     ["Test-capturetheflag"]
 


### PR DESCRIPTION
## Problem

```
Provisioning, deprovisioning, or updating resources for minetest failed: YunoHost was able to download the asset 'main' (https://github.com/minetest/minetest/archive/refs/tags/5.10.0.tar.gz) for minetest, but the asset doesn't match the expected checksum. This could mean that some temporary network failure happened on your server, OR the asset was somehow changed by the upstream maintainer (or a malicious actor?) and YunoHost packagers need to investigate and perhaps update the app manifest to take this change into account.
    Expected sha256 checksum: 2a3161c04e7389608006f01280eda30507f8bacfa1d6b64c2af1b820a62d2677
    Downloaded sha256 checksum: 13c559566937cfd9ed1cde594c20e7ab52f86dee0816ba12e828b14bb8e2c6ac
```

## Solution

- *fix minetest checksum²*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
